### PR TITLE
29 logging messages

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,13 +2,14 @@ import * as net from 'net';
 import {
     LanguageClient, ServerOptions, LanguageClientOptions
 } from 'vscode-languageclient';
-import { ExtensionContext, window, commands, extensions } from "vscode";
+import { ExtensionContext, window, commands, extensions, CodeAction, OutputChannel } from "vscode";
 import * as cp from "child_process";
 import * as getPort from "get-port";
 
 // module-level variable place holders
 let client : LanguageClient;
 let mroServerProcess : cp.ChildProcess;
+let outputChannel : OutputChannel;
 
 /**
  * Async sleep.
@@ -21,18 +22,28 @@ async function sleep(ms: number) {
 export function activate(context: ExtensionContext) {
     let connectionEstablished = false;
 
+    let extTitle = 'Python MRO';
+
+    // create an output channel for output debug information
+    outputChannel = window.createOutputChannel(extTitle);
+    context.subscriptions.push(outputChannel);
+
     // get an available port and start the MRO server
+    outputChannel.appendLine(`Ready to get an available port and to start the MRO server`);
     let connectionPort = 0;
     (async () => {
         connectionPort = await getPort({port: [3000, 3001, 3002]});
-        console.info(`using port ${connectionPort}`);
+        outputChannel.appendLine(`Got an available port ${connectionPort}`);
+        // console.info(`using port ${connectionPort}`);
         startMroServer(connectionPort);
     })();
 
     // server options knows how to connect to the MRO server
+    outputChannel.appendLine(`Ready to define the ServerOptions`);
     const serverOptions: ServerOptions = function() {
 		return new Promise((resolve, reject) => {
             let socketClient = new net.Socket();
+            outputChannel.appendLine(`Ready to connect to the MRO server via socket`);
 			socketClient.connect(connectionPort, "127.0.0.1", function() {
                 connectionEstablished = true;
 				resolve({
@@ -43,19 +54,22 @@ export function activate(context: ExtensionContext) {
 		});
     };
     // the language client options
+    outputChannel.appendLine(`Ready to define the LanguageClientOptions`);
     let clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'python' }]
     };
 
     // create the language client
+    outputChannel.appendLine(`Ready to instantiate a LanguageClient`);
     client = new LanguageClient(
         'pythonMro',
-        'Python MRO',
+        extTitle,
         serverOptions,
         clientOptions
     );
 
     // define the command handler for the show MRO command
+    outputChannel.appendLine(`Ready to register the show MRO command`);
     let showMroCommand = 'pythonMRO.showMRO';
     const showMroHandler = (content: string = 'No MRO List provided!') => {
         // show the MRO list in the right bottom pop-up box
@@ -63,9 +77,12 @@ export function activate(context: ExtensionContext) {
     };
     // register command
     context.subscriptions.push(commands.registerCommand(showMroCommand, showMroHandler));
+    outputChannel.appendLine(`Finished the registration of the show MRO command`);
 
     // delay the start of the client until the MRO server is connected
+    outputChannel.appendLine(`Ready to wait for the launch of MRO server and to start the client`);
     (async () => {
+        outputChannel.appendLine(`Wait for the start of the MRO server`);
         let startWaitTime = Date.now();
         while (!connectionEstablished) {
             await sleep(1000);
@@ -73,11 +90,14 @@ export function activate(context: ExtensionContext) {
                 break;
             }
         }
+        outputChannel.appendLine(`MRO server is ready`);
+        outputChannel.appendLine(`Ready to start the client`);
         client.start();
     })();
 }
 
 function startMroServer(port: number) {
+    outputChannel.appendLine(`Ready to start MRO Server`);
     // get extension root path
     let extPath = extensions.getExtension('kaiyan.python-mro').extensionPath;
     // use spawn to run the long-live MRO server instead of using 
@@ -89,6 +109,7 @@ function startMroServer(port: number) {
         shell: true,
         detached: true
     });
+    outputChannel.appendLine(`MRO server process spawned`);
     // unreference the MRO server process
     mroServerProcess.unref();
     // redirect the MRO server process I/O into this main process
@@ -103,9 +124,11 @@ function startMroServer(port: number) {
     });
     // kill the MRO server process in case of abnormal exit, like in unit test
     process.on('exit', killMROServerProcess);
+    outputChannel.appendLine(`MRO server handlers registered`);
 }
 
 export function deactivate(): Thenable<void> | undefined {
+    outputChannel.appendLine(`Ready to deactivate the Python MRO extension`);
     if (!client) {
         return undefined;
     }
@@ -115,6 +138,7 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 async function killMROServerProcess() {
+    outputChannel.appendLine(`Ready to kill the MRO server process`);
     let startKillTime = Date.now();
     while (!mroServerProcess.killed) {
         console.log(`Stopping the Python MRO language server process of PID ${mroServerProcess.pid}`);
@@ -128,5 +152,6 @@ async function killMROServerProcess() {
             return Promise.resolve(false);
         }
     }
+    outputChannel.appendLine(`MRO server process is killed`);
     return Promise.resolve(true);
 }


### PR DESCRIPTION
Solves issue #29 by adding logging support to show debug information about the extension execution in a separate output channel.
